### PR TITLE
Unify affine transformation determination mismatch between gdalwrite.grid and tif storage managers

### DIFF
--- a/stg/dll/src/DllMain.cpp
+++ b/stg/dll/src/DllMain.cpp
@@ -128,38 +128,66 @@ exit:
 // ------------------------------------------------------------------------
 
 #include "FilePtrHandle.h"
+auto GetFactorFromGridDomain(const AbstrDataItem* grid_adi) -> DPoint {
+	dms_assert(grid_adi);
+	auto grid_adu = grid_adi->GetAbstrDomainUnit();
+	dms_assert(grid_adi);
 
-bool WriteGeoRefFile(const AbstrDataItem* diGrid, WeakStr geoRefFileName)
+	auto [grid_begin, grid_end] = grid_adu->GetRangeAsDRect();
+
+	auto grid_projection = grid_adu->GetProjection();
+	auto factor = (grid_adu) ? grid_projection->Factor() : DPoint(1.0, 1.0);
+	auto f2 = factor;
+
+	if (factor.X() < 0) { 
+		f2.X() = -factor.X(); 
+		grid_begin.Col() = grid_end.Col(); 
+	}
+
+	if (factor.Y() > 0) { 
+		f2.Y() = -factor.Y(); 
+		grid_begin.Row() = grid_end.Row(); 
+	}
+	return f2;
+}
+
+auto GetOffsetFromGridDomainAndFactor(const AbstrDataItem* grid_adi, DPoint& factor, bool offset_to_top_left_cell) -> DPoint {
+	dms_assert(grid_adi);
+	auto grid_adu = grid_adi->GetAbstrDomainUnit();
+	dms_assert(grid_adi);
+
+	auto [grid_begin, grid_end] = grid_adu->GetRangeAsDRect();
+	auto grid_projection = grid_adu->GetProjection();
+
+	auto offset = ((grid_projection) ? grid_projection->Offset() : DPoint()) + grid_begin * factor; // + 0.5 * factor;
+	offset = offset_to_top_left_cell ? offset + 0.5 * factor : offset;
+	return offset;
+}
+
+bool WriteGeoRefFile(const AbstrDataItem* grid_adi, WeakStr geoRefFileName)
 {
-	dms_assert(diGrid);
-	const AbstrUnit* colDomain = diGrid->GetAbstrDomainUnit();
-	dms_assert(diGrid);
+	dms_assert(grid_adi);
+	const AbstrUnit* colDomain = grid_adi->GetAbstrDomainUnit();
+	dms_assert(grid_adi);
 
-	auto [gridBegin, gridEnd] = colDomain->GetRangeAsDRect();
-	
 	FilePtrHandle bmpwHnd; bmpwHnd.OpenFH(geoRefFileName, FCM_CreateAlways, true, NR_PAGES_HDRFILE);
 
 	if (bmpwHnd == NULL)
 		return false;
 
 	DMS_CALL_BEGIN
-
 		// MapObjects coordinate system is in cartesian order (LeftBottom -> RightTop)
 		// and wants offset of center of TopLeft cell, positive x factor and negative y factor.
 		// In DMS we defined grid as a series of half-open intervals starting from BottomLeft corner of BottomLeft cell.
-
 		const UnitProjection* colProj = colDomain->GetProjection(); // note that this doesn't have to be the composite projection
 
-		DPoint factor = (colProj) ? colProj->Factor() : DPoint(1.0, 1.0), f2 = factor;
-			if (factor.X() < 0) { f2.X() = -factor.X(); gridBegin.Col() = gridEnd.Col(); }
-			if (factor.Y() > 0) { f2.Y() = -factor.Y(); gridBegin.Row() = gridEnd.Row(); }
+		auto factor = GetFactorFromGridDomain(grid_adi);
+		auto offset = GetOffsetFromGridDomainAndFactor(grid_adi, factor);
 
-		DPoint offset = ((colProj) ? colProj->Offset() : DPoint()) + gridBegin * factor + 0.5 * f2;
-
-		fprintf(bmpwHnd, "%.9G\n", f2.X());
+		fprintf(bmpwHnd, "%.9G\n", factor.X());
 		fprintf(bmpwHnd, "%.9G\n", Float64(0.0));
 		fprintf(bmpwHnd, "%.9G\n", Float64(0.0));
-		fprintf(bmpwHnd, "%.9G\n", f2.Y());
+		fprintf(bmpwHnd, "%.9G\n", factor.Y());
 		fprintf(bmpwHnd, "%.9G\n", offset.X());
 		fprintf(bmpwHnd, "%.9G\n", offset.Y());
 

--- a/stg/dll/src/DllMain.cpp
+++ b/stg/dll/src/DllMain.cpp
@@ -128,7 +128,7 @@ exit:
 // ------------------------------------------------------------------------
 
 #include "FilePtrHandle.h"
-auto GetFactorFromGridDomain(const AbstrDataItem* grid_adi) -> DPoint {
+auto GetAffineTransformationFromGridDataItem(const AbstrDataItem* grid_adi, bool offset_to_top_left_cell) -> Transformation<Float64> {
 	dms_assert(grid_adi);
 	auto grid_adu = grid_adi->GetAbstrDomainUnit();
 	dms_assert(grid_adi);
@@ -139,29 +139,24 @@ auto GetFactorFromGridDomain(const AbstrDataItem* grid_adi) -> DPoint {
 	auto factor = (grid_adu) ? grid_projection->Factor() : DPoint(1.0, 1.0);
 	auto f2 = factor;
 
-	if (factor.X() < 0) { 
-		f2.X() = -factor.X(); 
-		grid_begin.Col() = grid_end.Col(); 
+	if (factor.X() < 0) {
+		f2.X() = -factor.X();
+		grid_begin.Col() = grid_end.Col();
 	}
 
-	if (factor.Y() > 0) { 
-		f2.Y() = -factor.Y(); 
-		grid_begin.Row() = grid_end.Row(); 
+	if (factor.Y() > 0) {
+		f2.Y() = -factor.Y();
+		grid_begin.Row() = grid_end.Row();
 	}
-	return f2;
-}
 
-auto GetOffsetFromGridDomainAndFactor(const AbstrDataItem* grid_adi, DPoint& factor, bool offset_to_top_left_cell) -> DPoint {
-	dms_assert(grid_adi);
-	auto grid_adu = grid_adi->GetAbstrDomainUnit();
-	dms_assert(grid_adi);
-
-	auto [grid_begin, grid_end] = grid_adu->GetRangeAsDRect();
 	auto grid_projection = grid_adu->GetProjection();
-
-	auto offset = ((grid_projection) ? grid_projection->Offset() : DPoint()) + grid_begin * factor; // + 0.5 * factor;
-	offset = offset_to_top_left_cell ? offset + 0.5 * factor : offset;
-	return offset;
+	auto offset = ((grid_projection) ? grid_projection->Offset() : DPoint()) + grid_begin * factor;
+	
+	if (offset_to_top_left_cell)
+		offset += 0.5 * f2;
+	
+	auto affine_transformation = Transformation(offset, factor);
+	return affine_transformation;
 }
 
 bool WriteGeoRefFile(const AbstrDataItem* grid_adi, WeakStr geoRefFileName)
@@ -180,16 +175,14 @@ bool WriteGeoRefFile(const AbstrDataItem* grid_adi, WeakStr geoRefFileName)
 		// and wants offset of center of TopLeft cell, positive x factor and negative y factor.
 		// In DMS we defined grid as a series of half-open intervals starting from BottomLeft corner of BottomLeft cell.
 		const UnitProjection* colProj = colDomain->GetProjection(); // note that this doesn't have to be the composite projection
-
-		auto factor = GetFactorFromGridDomain(grid_adi);
-		auto offset = GetOffsetFromGridDomainAndFactor(grid_adi, factor);
-
-		fprintf(bmpwHnd, "%.9G\n", factor.X());
+		auto affine_transformation = GetAffineTransformationFromGridDataItem(grid_adi);
+		
+		fprintf(bmpwHnd, "%.9G\n", affine_transformation.Factor().X());
 		fprintf(bmpwHnd, "%.9G\n", Float64(0.0));
 		fprintf(bmpwHnd, "%.9G\n", Float64(0.0));
-		fprintf(bmpwHnd, "%.9G\n", factor.Y());
-		fprintf(bmpwHnd, "%.9G\n", offset.X());
-		fprintf(bmpwHnd, "%.9G\n", offset.Y());
+		fprintf(bmpwHnd, "%.9G\n", affine_transformation.Factor().Y());
+		fprintf(bmpwHnd, "%.9G\n", affine_transformation.Offset().X());
+		fprintf(bmpwHnd, "%.9G\n", affine_transformation.Offset().Y());
 
 	DMS_CALL_END
 

--- a/stg/dll/src/StgBase.h
+++ b/stg/dll/src/StgBase.h
@@ -36,6 +36,7 @@ granted by an additional written contract for support, assistance and/or develop
 
 #include <set>
 #include "geo/color.h"
+#include "geo/transform.h"
 
 #ifdef DMSTGDLL_EXPORTS
 #	define STGDLL_CALL __declspec(dllexport)

--- a/stg/dll/src/StgImpl.h
+++ b/stg/dll/src/StgImpl.h
@@ -49,6 +49,8 @@ bool              TableDomain_IsAttr(const AbstrUnit* domain, const AbstrDataIte
 STGDLL_CALL SharedUnit FindProjectionRef (const TreeItem* storageHolder, const AbstrUnit* uDomain);
 STGDLL_CALL SharedUnit FindProjectionBase(const TreeItem* storageHolder, const AbstrUnit* uDomain);
 
+auto GetFactorFromGridDomain(const AbstrDataItem* grid_adi) -> DPoint;
+auto GetOffsetFromGridDomainAndFactor(const AbstrDataItem* grid_adi, DPoint& factor, bool offset_to_top_left_cell = true) -> DPoint;
 bool WriteGeoRefFile(const AbstrDataItem* diGrid, WeakStr geoRefFileName);
 void GetImageToWorldTransformFromFile(TreeItem* storageHolder, WeakStr geoRefFileName);
 

--- a/stg/dll/src/StgImpl.h
+++ b/stg/dll/src/StgImpl.h
@@ -49,8 +49,7 @@ bool              TableDomain_IsAttr(const AbstrUnit* domain, const AbstrDataIte
 STGDLL_CALL SharedUnit FindProjectionRef (const TreeItem* storageHolder, const AbstrUnit* uDomain);
 STGDLL_CALL SharedUnit FindProjectionBase(const TreeItem* storageHolder, const AbstrUnit* uDomain);
 
-auto GetFactorFromGridDomain(const AbstrDataItem* grid_adi) -> DPoint;
-auto GetOffsetFromGridDomainAndFactor(const AbstrDataItem* grid_adi, DPoint& factor, bool offset_to_top_left_cell = true) -> DPoint;
+auto GetAffineTransformationFromGridDataItem(const AbstrDataItem* grid_adi, bool offset_to_top_left_cell=true)->Transformation<Float64>;
 bool WriteGeoRefFile(const AbstrDataItem* diGrid, WeakStr geoRefFileName);
 void GetImageToWorldTransformFromFile(TreeItem* storageHolder, WeakStr geoRefFileName);
 

--- a/stg/dll/src/gdal/gdal_base.cpp
+++ b/stg/dll/src/gdal/gdal_base.cpp
@@ -1069,23 +1069,22 @@ auto GetUnitSizeInMeters(const AbstrUnit* projectionBaseUnit) -> Float64
 	return result;
 }
 
-auto GetAffineTransformationFromDataItem(const TreeItem* storageHolder) -> affine_transformation
+auto GetAffineTransformationFromDataItem(const TreeItem* storageHolder) -> gdal_affine_crd_transformation
 {
-	affine_transformation affine_transformation;
+	gdal_affine_crd_transformation gdal_affine_transformation;
 
 	if (!IsDataItem(storageHolder))
 		return {};
 
 	auto grid_adi = AsDataItem(storageHolder);
-	auto factor = GetFactorFromGridDomain(grid_adi);
-	auto offset = GetOffsetFromGridDomainAndFactor(grid_adi, factor, false);
+	auto affine_transformation = GetAffineTransformationFromGridDataItem(grid_adi, false);
 
-	affine_transformation.x_offset = offset.X();
-	affine_transformation.y_offset = offset.Y();
-	affine_transformation.x_scale = factor.X();
-	affine_transformation.y_scale = factor.Y();
+	gdal_affine_transformation.x_offset = affine_transformation.Offset().X();
+	gdal_affine_transformation.y_offset = affine_transformation.Offset().Y();
+	gdal_affine_transformation.x_scale = affine_transformation.Factor().X();
+	gdal_affine_transformation.y_scale = affine_transformation.Factor().Y();
 
-	return affine_transformation;
+	return gdal_affine_transformation;
 }
 
 auto GetOGRSpatialReferenceFromDataItems(const TreeItem* storageHolder) -> std::optional<OGRSpatialReference>

--- a/stg/dll/src/gdal/gdal_base.cpp
+++ b/stg/dll/src/gdal/gdal_base.cpp
@@ -1076,16 +1076,12 @@ auto GetAffineTransformationFromDataItem(const TreeItem* storageHolder) -> affin
 	if (!IsDataItem(storageHolder))
 		return {};
 
-	auto adi = AsDataItem(storageHolder);
-	const AbstrUnit* colDomain = adi->GetAbstrDomainUnit();
-	auto unit_projection = colDomain->GetProjection();
-	auto grid_extends = colDomain->GetRangeAsDRect();
+	auto grid_adi = AsDataItem(storageHolder);
+	auto factor = GetFactorFromGridDomain(grid_adi);
+	auto offset = GetOffsetFromGridDomainAndFactor(grid_adi, factor, false);
 
-	auto transformation = UnitProjection::GetCompositeTransform(unit_projection); 
-	auto factor = transformation.Factor();
-
-	affine_transformation.x_offset = transformation.Offset().X();
-	affine_transformation.y_offset = transformation.Offset().Y();
+	affine_transformation.x_offset = offset.X();
+	affine_transformation.y_offset = offset.Y();
 	affine_transformation.x_scale = factor.X();
 	affine_transformation.y_scale = factor.Y();
 

--- a/stg/dll/src/gdal/gdal_base.h
+++ b/stg/dll/src/gdal/gdal_base.h
@@ -105,7 +105,7 @@ struct FieldInfo
 	WeakDataItemInterestPtr m_DataHolder; // Ptr to keep data alive until all data for layer items of interest is present.
 };
 
-struct affine_transformation
+struct gdal_affine_crd_transformation
 {
 	Float64 x_offset = 0.0;
 	Float64 x_scale = 1.0;


### PR DESCRIPTION
Range of grid domain unit may be limited based on results from internal GetRange function, see:
![image](https://github.com/user-attachments/assets/b796ae1b-8aad-4634-957f-48e79dd4f770)

This was properly taken into account by the affine transformation as calculated in DllMain.cpp's WriteGeoRefFile function but wasn't in gdalbase.cpp GetAffineTransformationFromDataItem function. This PR implements a unification of affine transformation determination for offset and factor.

Release unit tests passed succesfully.