### PR TITLE
Fix issue 919: (re)implemented copy and find in detailpage functionality

### DIFF
--- a/qtgui/exe/src/DmsDetailPages.cpp
+++ b/qtgui/exe/src/DmsDetailPages.cpp
@@ -429,6 +429,17 @@ QSize DmsDetailPages::minimumSizeHint() const
     return QSize(m_default_width, 0);
 }
 
+void DmsDetailPages::keyPressEvent(QKeyEvent* event)
+{
+    if (event->matches(QKeySequence::Copy))
+    {
+        copy();
+        event->accept();
+        return;
+    }
+    return QWidget::keyPressEvent(event);
+}
+
 void DmsDetailPages::resizeEvent(QResizeEvent* event)
 {
     m_current_width = width();

--- a/qtgui/exe/src/DmsDetailPages.h
+++ b/qtgui/exe/src/DmsDetailPages.h
@@ -27,10 +27,12 @@ class DmsDetailPages : public QUpdatableWebBrowser
 {
 
 public:
+
 	DmsDetailPages(QWidget* parent = nullptr);
 	bool update() override;
 	QSize sizeHint() const override;
 	QSize minimumSizeHint() const override;
+	void keyPressEvent(QKeyEvent* event) override;
 	auto activeDetailPageFromName(CharPtrRange sName)->ActiveDetailPage;
 
 	ActiveDetailPage m_active_detail_page = ActiveDetailPage::GENERAL;

--- a/qtgui/exe/src/UpdatableBrowser.cpp
+++ b/qtgui/exe/src/UpdatableBrowser.cpp
@@ -39,7 +39,7 @@ FindTextWindow::FindTextWindow(QWidget* parent)
 
 void FindTextWindow::findInQTextBrowser(bool backwards)
 {
-    auto* updatable_text_browser = dynamic_cast<QUpdatableTextBrowser*>(parent());
+    auto* updatable_text_browser = dynamic_cast<QUpdatableWebBrowser*>(parent());
     assert(updatable_text_browser);
 
     // set find flag
@@ -66,8 +66,8 @@ void FindTextWindow::findInText(bool backwards)
     }
 
     auto* updatable_web_browser = dynamic_cast<QUpdatableWebBrowser*>(current_parent);
-    //if (updatable_web_browser)
-    //    findInQWebEnginePage(backwards);
+    if (updatable_web_browser)
+        findInQTextBrowser(backwards);
 
     return;
 }


### PR DESCRIPTION
Reverting back to QTextbrowser from QTWebbrowser (chromium) caused copy and find in text for the detailpage to break. This PR fixes this. 

See issue #919.
 