### PR TITLE
Fix issue #899 

### DIFF
--- a/stg/dll/src/tif/TifImp.cpp
+++ b/stg/dll/src/tif/TifImp.cpp
@@ -423,7 +423,7 @@ bool TifImp::OpenForWriteDirect(WeakStr name)
 {
 	GetWritePermission(name);
 
-	m_TiffHandle = TIFFOpen(ConvertDmsFileName(name).c_str(), "a");
+	m_TiffHandle = TIFFOpen(ConvertDmsFileName(name).c_str(), "w");
 	if (m_TiffHandle)
 		TIFFSetField(m_TiffHandle, TIFFTAG_SOFTWARE, "GeoDMS " BOOST_STRINGIZE( DMS_VERSION_MAJOR ) );
 	return m_TiffHandle;


### PR DESCRIPTION
Tif files openened/created for writing were opened using append mode "a", which caused consequtive writes to grow the tiffile usually by the given domain of the dataitem. This was never a problem as geodms handled temporary (.tmp) files itself and deleted these accordingly. Changing "a" to "w" makes sure that a new tif file is always created on write, which is in line with the new state: new writes to storage targets are always done to fresh files.