### PR TITLE
Disabled darkmode

### DIFF
--- a/qtgui/exe/src/main_qt.cpp
+++ b/qtgui/exe/src/main_qt.cpp
@@ -300,6 +300,7 @@ protected:
 
 int main_without_SE_handler(int argc, char *argv[]) {
     try {
+        qputenv("QT_QPA_PLATFORM", "windows:darkmode=1"); // https://doc.qt.io/qt-6/qguiapplication.html#platform-specific-arguments
         CmdLineSetttings settingsFrame;
         garbage_t geoDmsResources; // destruct resources after app completion
 


### PR DESCRIPTION
The geodms custom color palette is not yet visually compatible with system darkmode palette: dark qt widget palette defaults cause some sections of geodms to become unreadable or flatout visually unpleasant to see (detail pages).