### PR TITLE
Placeholder resolving from environment block

### DIFF
--- a/profiler/Profiler.py
+++ b/profiler/Profiler.py
@@ -54,7 +54,7 @@ class Experiment:
         total_write = self.result['log']['total_write_bytes'][-1]
         max_threads = max(self.result['log']['num_threads'])
         
-        return {"status":status, "start_time":start_time, "end_time":end_time, "duration":duration, "highest_commit":highest_commit, "total_read":total_read, "total_write":total_write, "max_threads":max_threads}
+        return {"status":status, "command":self.command, "start_time":start_time, "end_time":end_time, "duration":duration, "highest_commit":highest_commit, "total_read":total_read, "total_write":total_write, "max_threads":max_threads}
 
 def readLog(log_filename, filter=None):
     ret = {"time":[], "text":[]}
@@ -512,7 +512,8 @@ def VisualizeExperiments(experiments, show_figure:bool=True, vgroups=[("cpu_perc
     colors = []
     labels = []
     for i, exp in enumerate(experiments):
-        colors.append(Category10[10][i])
+        color_index = i % 9
+        colors.append(Category10[10][color_index])
         fldrname, filename = getExperimentFileName(exp)
         labels.append(filename[:-4])
 
@@ -560,8 +561,8 @@ def VisualizeExperiments(experiments, show_figure:bool=True, vgroups=[("cpu_perc
         for i, exp in enumerate(experiments):
             if not exp:
                 continue
-                
-            color = Category10[10][i]
+            color_index = i % 9
+            color = Category10[10][color_index]
 
             fldrname, filename = getExperimentFileName(exp)
             if type(vgroup[0]) is tuple: # do something with this vgroup case

--- a/tic/dll/src/stg/AbstrStoragemanager.cpp
+++ b/tic/dll/src/stg/AbstrStoragemanager.cpp
@@ -37,7 +37,8 @@
 #include "TreeItemContextHandle.h"
 #include "TreeItemProps.h"
 #include "stg/StorageClass.h"
-
+#include <windows.h>
+#include "processenv.h"
 
 #if defined(MG_DEBUG)
 #define MG_DEBUG_ASM 1
@@ -194,6 +195,16 @@ SharedStr GetRegConfigSetting(const TreeItem* configRoot, CharPtr key, CharPtr d
 	}
 
 	return SharedStr(defaultValue);
+}
+
+auto GetEnvironmentSetting(CharPtr placeHolder) -> SharedStr
+{
+	const UInt64 buffer_size = 512;
+	char buffer[buffer_size];
+	auto number_of_characters_in_buffer = GetEnvironmentVariableA("SourceDataDir", buffer, buffer_size);
+	if (number_of_characters_in_buffer > 0)
+		return SharedStr(buffer, buffer+number_of_characters_in_buffer);
+	return {};
 }
 
 SharedStr GetConvertedRegConfigSetting(const TreeItem* configRoot, CharPtr key, CharPtr defaultValue)
@@ -390,20 +401,22 @@ SharedStr GetPlaceholderValue(CharPtr subDirName, CharPtr placeHolder, bool must
 		throwErrorD("Unknown placeholder", placeHolder);
 	return SharedStr();
 }
-
 SharedStr GetPlaceholderValue(const TreeItem* configStore, CharPtr placeHolder)
 {
 	if (!stricmp(placeHolder, "caseDir"))           return GetCaseDir        (configStore);
 	if (!stricmp(placeHolder, "storageBaseName"  )) return GetStorageBaseName(configStore);
 	if (!stricmp(placeHolder, "currDir"))           return SharedStr( SessionData::Curr()->GetConfigLoadDir() );
-
 	if (!stricmp(placeHolder, "sourceDataProjDir")) return GetSourceDataProjDir(SessionData::Curr()->GetConfigRoot());
 	if (!stricmp(placeHolder, "dataDir"          )) return GetDataDir          (SessionData::Curr()->GetConfigRoot());
 
-	SharedStr result = GetPlaceholderValue(SessionData::Curr()->GetConfigDir().c_str(), placeHolder, false);
+	auto result = GetEnvironmentSetting(placeHolder);
 	if (!result.empty())
 		return result;
 
+	result = GetPlaceholderValue(SessionData::Curr()->GetConfigDir().c_str(), placeHolder, false);
+	if (!result.empty())
+		return result;
+	//ss
 	result = GetConvertedRegConfigSetting(SessionData::Curr()->GetConfigRoot(), placeHolder, "");
 	if (!result.empty())
 		return result;


### PR DESCRIPTION
Python Subprocess.Popen env variable sets the process [environment block](https://learn.microsoft.com/en-us/windows/win32/procthread/environment-variables). This PR makes sure that placeholders are also resolved based on the environment block, next to known or unknown registry keys. Without this PR the env parameter cannot be used to communicate with geodms, in light of the regression testing rework.

Simple test code to test out interpreting the environment block from c++:

geodms:
```cpp
container test
{
	parameter<string> test := Expand(.,"%SourceDataDir%"), StorageName="%projDir%/data/test.txt", StorageType="str", StorageReadOnly="False";
}
```

python:
```python
import subprocess
import os

cmd_parts = ['cmd','/k', 'title', 'test','&&', 'call', 'C:/dev/geodms/geodms_v17/bin/Release/x64/GeoDmsGuiQt.exe','/S1','/S2', '/S3',\
             'C:/Users/Cicada/Desktop/test_subprocess_env/cfg/test_subprocess_env.dms','test']

custom_env = os.environ.copy()
custom_env['SourceDataDir'] = 'I changed the sourcedatadir using the environment block'

parent_process_open_handle = subprocess.Popen(
    cmd_parts,
    cwd=None, env=custom_env, 
    creationflags=subprocess.CREATE_NEW_CONSOLE
)
```

Output in "%projDir%/data/test.txt" should be equal to custom_env['SourceDataDir'].