### PR TITLE
Removed char limit for Descr field visualization in DP General 

### DIFF
--- a/tic/dll/src/Xml/XmlTreeOut.h
+++ b/tic/dll/src/Xml/XmlTreeOut.h
@@ -100,7 +100,7 @@ struct XML_Table : XML_OutElement
 		OutStream().WriteAttr("bgcolor", color);
 		Row::Cell cell(row);
 		OutStream().WriteAttr("COLSPAN", colSpan);
-		OutStream().WriteTrimmed(value);
+		OutStream().WriteValue(value);
 	}
 
 	void EditableNameValueRow(CharPtr propName, CharPtr propValue, const TreeItem* context = 0)


### PR DESCRIPTION
Description should be always displayed as the user intended.