### PR TITLE
Fixed #1003

### DIFF
--- a/qtgui/exe/res/ui/DmsEventLogSelection.ui
+++ b/qtgui/exe/res/ui/DmsEventLogSelection.ui
@@ -198,7 +198,7 @@
      <rect>
       <x>210</x>
       <y>90</y>
-      <width>121</width>
+      <width>141</width>
       <height>20</height>
      </rect>
     </property>
@@ -342,9 +342,54 @@
      <rect>
       <x>20</x>
       <y>90</y>
-      <width>261</width>
+      <width>181</width>
       <height>20</height>
      </rect>
+    </property>
+    <property name="palette">
+     <palette>
+      <active>
+       <colorrole role="WindowText">
+        <brush brushstyle="SolidPattern">
+         <color alpha="228">
+          <red>168</red>
+          <green>168</green>
+          <blue>0</blue>
+         </color>
+        </brush>
+       </colorrole>
+       <colorrole role="Text">
+        <brush brushstyle="SolidPattern">
+         <color alpha="228">
+          <red>168</red>
+          <green>168</green>
+          <blue>0</blue>
+         </color>
+        </brush>
+       </colorrole>
+      </active>
+      <inactive>
+       <colorrole role="WindowText">
+        <brush brushstyle="SolidPattern">
+         <color alpha="228">
+          <red>168</red>
+          <green>168</green>
+          <blue>0</blue>
+         </color>
+        </brush>
+       </colorrole>
+       <colorrole role="Text">
+        <brush brushstyle="SolidPattern">
+         <color alpha="228">
+          <red>168</red>
+          <green>168</green>
+          <blue>0</blue>
+         </color>
+        </brush>
+       </colorrole>
+      </inactive>
+      <disabled/>
+     </palette>
     </property>
     <property name="text">
      <string>Case mix-up warnings</string>

--- a/qtgui/exe/src/DmsEventLog.cpp
+++ b/qtgui/exe/src/DmsEventLog.cpp
@@ -34,6 +34,7 @@ static QColor html_purple = QColor(128, 0, 128); // EventLog: request in Backgro
 static QColor html_black = QColor(0, 0, 0); // EventLog: commands
 static QColor html_gray = QColor(128, 128, 128); // EventLog: other
 static QColor html_darkorange = QColor(255, 140, 0); // EventLog: warning
+static QColor html_darkyellow = QColor(168, 168, 0); // EventLog: warning
 static QColor html_red = QColor(255, 0, 0); // EventLog: error
 static QColor html_brown = QColor(165, 42, 42); // EventLog: memory
 
@@ -102,12 +103,13 @@ QVariant EventLogModel::data(const QModelIndex& index, int role) const
 		auto return_color = QColor();
 		switch (item_data.m_SeverityType) 
 		{
-		case SeverityTypeID::ST_DispError:// error
+		case SeverityTypeID::ST_DispError:
 		case SeverityTypeID::ST_FatalError:
 		case SeverityTypeID::ST_Error: {return html_red; }
-		case SeverityTypeID::ST_Warning: {return html_darkorange; }// warning
-		case SeverityTypeID::ST_MinorTrace: {return_color = html_ForestGreen; break; } // minor trace							  
-		case SeverityTypeID::ST_MajorTrace: { return_color = html_DarkGreen; break; }// major trace
+		case SeverityTypeID::ST_Warning: {return html_darkorange; }
+		case SeverityTypeID::ST_CaseMixup: { return html_darkyellow; }
+		case SeverityTypeID::ST_MinorTrace: {return_color = html_ForestGreen; break; }
+		case SeverityTypeID::ST_MajorTrace: { return_color = html_DarkGreen; break; }
 		}
 
 		switch (item_data.m_MsgCategory)
@@ -187,8 +189,10 @@ bool EventLogModel::itemPassesFilter(const MsgData& msgLine) const
 	auto item_passes_type_filter = itemPassesTypeFilter(msgLine);
 	auto item_is_warning_or_error = (msgLine.m_SeverityType == SeverityTypeID::ST_CaseMixup || msgLine.m_SeverityType == SeverityTypeID::ST_Warning || msgLine.m_SeverityType == SeverityTypeID::ST_Error);
 	if (msgLine.m_MsgCategory == MsgCategory::progress || item_is_warning_or_error)
+	{
 		if (!item_passes_type_filter)
 			return false;
+	}
 	else
 	{
 		auto item_passes_category_filter = itemPassesCategoryFilter(msgLine);
@@ -238,6 +242,7 @@ void EventLogModel::refilter()
 	m_filtered_indices.clear();
 
 	auto eventlog = MainWindow::TheOne()->m_eventlog.get();
+	assert(eventlog);
 
 	auto text_filter_string = eventlog->m_eventlog_filter->m_text_filter->text();
 	m_TextFilterAsByteArray = text_filter_string.toUtf8();
@@ -252,15 +257,20 @@ void EventLogModel::refilter()
 
 void EventLogModel::refilterForTextFilter()
 {
-	MainWindow::TheOne()->m_eventlog->m_text_filter_active = true;
-	MainWindow::TheOne()->m_eventlog->m_eventlog_filter->m_clear_text_filter->setDisabled(false);
-	MainWindow::TheOne()->m_eventlog->m_eventlog_filter->m_activate_text_filter->setDisabled(true);
+	auto eventlog = MainWindow::TheOne()->m_eventlog.get();
+	assert(eventlog);
+
+	eventlog->m_text_filter_active = true;
+	eventlog->m_eventlog_filter->m_clear_text_filter->setDisabled(false);
+	eventlog->m_eventlog_filter->m_activate_text_filter->setDisabled(true);
 	refilter();
 }
 
 void EventLogModel::writeSettingsOnToggle(bool newValue)
 {
 	auto eventlog = MainWindow::TheOne()->m_eventlog.get();
+	assert(eventlog);
+
 	auto eventlog_filter_ptr = eventlog->m_eventlog_filter.get();
 	bool clearOnOpen = eventlog_filter_ptr->m_opening_new_configuration->isChecked();
 	bool clearOnReopen = eventlog_filter_ptr->m_reopening_current_configuration->isChecked();
@@ -272,10 +282,8 @@ void EventLogModel::writeSettingsOnToggle(bool newValue)
 		eventlog_filter_ptr->m_reopening_current_configuration->setChecked(newValue);
 	}
 
-	auto dms_reg_status_flags = GetRegStatusFlags();
-	setSF(clearOnOpen, dms_reg_status_flags, RSF_EventLog_ClearOnLoad);
-	setSF(clearOnReopen, dms_reg_status_flags, RSF_EventLog_ClearOnReLoad);
-	SetRegStatusFlags(dms_reg_status_flags);
+	SetStatusFlag(RSF_EventLog_ClearOnLoad, clearOnOpen);
+	SetStatusFlag(RSF_EventLog_ClearOnReLoad, clearOnReopen);
 }
 
 void EventLogModel::updateOnNewMessages()
@@ -412,25 +420,32 @@ DmsEventLog::DmsEventLog(QWidget* parent)
 	m_eventlog_filter->setFocusPolicy(Qt::ClickFocus);
 	auto dms_reg_status_flags = GetRegStatusFlags();
 
-	m_eventlog_filter->m_date_time->setChecked(dms_reg_status_flags & RSF_EventLog_ShowDateTime);
-	m_eventlog_filter->m_thread   ->setChecked(dms_reg_status_flags & RSF_EventLog_ShowThreadID);
-	m_eventlog_filter->m_category ->setChecked(dms_reg_status_flags & RSF_EventLog_ShowCategory);
+	m_eventlog_filter->m_minor_trace_filter->setChecked(GetRegStatusFlags() & RSF_EventLog_ShowMinorTrace);
+	m_eventlog_filter->m_major_trace_filter->setChecked(!(GetRegStatusFlags() & RSF_EventLog_HideMajorTrace));
+	m_eventlog_filter->m_case_mixup_warning_filter->setChecked(!(GetRegStatusFlags() & RSF_EventLog_HideDepreciated));
+	m_eventlog_filter->m_warning_filter->setChecked(!(GetRegStatusFlags() & RSF_EventLog_HideWarning));
+	m_eventlog_filter->m_error_filter->setChecked(!(GetRegStatusFlags() & RSF_EventLog_HideError));
+	m_eventlog_filter->m_read_filter->setChecked(!(GetRegStatusFlags() & RSF_EventLog_HideStorageRead));
+	m_eventlog_filter->m_write_filter->setChecked(!(GetRegStatusFlags() & RSF_EventLog_HideStorageWrite));
 
-	connect(m_eventlog_filter->m_minor_trace_filter, &QCheckBox::toggled, eventlog_model_ptr, &EventLogModel::refilter);
-	connect(m_eventlog_filter->m_major_trace_filter, &QCheckBox::toggled, eventlog_model_ptr, &EventLogModel::refilter);
-	connect(m_eventlog_filter->m_warning_filter, &QCheckBox::toggled, eventlog_model_ptr, &EventLogModel::refilter);
-	connect(m_eventlog_filter->m_error_filter, &QCheckBox::toggled, eventlog_model_ptr, &EventLogModel::refilter);
-	connect(m_eventlog_filter->m_read_filter, &QCheckBox::toggled, eventlog_model_ptr, &EventLogModel::refilter);
-	connect(m_eventlog_filter->m_write_filter, &QCheckBox::toggled, eventlog_model_ptr, &EventLogModel::refilter);
+	connect(m_eventlog_filter->m_minor_trace_filter, &QCheckBox::toggled, [eventlog_model_ptr](bool checkedState) { SetStatusFlag(RSF_EventLog_ShowMinorTrace, checkedState); eventlog_model_ptr->refilter(); });
+	connect(m_eventlog_filter->m_major_trace_filter, &QCheckBox::toggled, [eventlog_model_ptr](bool checkedState) { SetStatusFlag(RSF_EventLog_HideMajorTrace, !checkedState); eventlog_model_ptr->refilter(); });
+	connect(m_eventlog_filter->m_case_mixup_warning_filter, &QCheckBox::toggled, [eventlog_model_ptr](bool checkedState) { SetStatusFlag(RSF_EventLog_HideDepreciated, !checkedState); eventlog_model_ptr->refilter(); });
+	connect(m_eventlog_filter->m_warning_filter, &QCheckBox::toggled, [eventlog_model_ptr](bool checkedState) { SetStatusFlag(RSF_EventLog_HideWarning, !checkedState); eventlog_model_ptr->refilter(); });
+	connect(m_eventlog_filter->m_error_filter, &QCheckBox::toggled, [eventlog_model_ptr](bool checkedState) { SetStatusFlag(RSF_EventLog_HideError, !checkedState); eventlog_model_ptr->refilter(); });
+	connect(m_eventlog_filter->m_read_filter, &QCheckBox::toggled, [eventlog_model_ptr](bool checkedState) { SetStatusFlag(RSF_EventLog_HideStorageRead, !checkedState); eventlog_model_ptr->refilter(); });
+	connect(m_eventlog_filter->m_write_filter, &QCheckBox::toggled, [eventlog_model_ptr](bool checkedState) { SetStatusFlag(RSF_EventLog_HideStorageWrite, !checkedState); eventlog_model_ptr->refilter(); });
 
-	m_eventlog_filter->m_case_mixup_warning_filter->setChecked(!EventLog_HideDepreciatedCaseMixupWarnings());
-	connect(m_eventlog_filter->m_case_mixup_warning_filter, &QCheckBox::toggled, [](bool checkedState) { SetCachedStatusFlag(RSF_EventLog_HideDepreciated, !checkedState); });
 
-	connect(m_eventlog_filter.get()->m_category_filter_commands, &QCheckBox::toggled, eventlog_model_ptr, &EventLogModel::refilter);
-	connect(m_eventlog_filter.get()->m_category_filter_memory, &QCheckBox::toggled, eventlog_model_ptr, &EventLogModel::refilter);
-	connect(m_eventlog_filter.get()->m_connection_filter, &QCheckBox::toggled, eventlog_model_ptr, &EventLogModel::refilter);
-	connect(m_eventlog_filter.get()->m_request_filter, &QCheckBox::toggled, eventlog_model_ptr, &EventLogModel::refilter);
-	connect(m_eventlog_filter.get()->m_category_filter_other, &QCheckBox::toggled, eventlog_model_ptr, &EventLogModel::refilter);
+	m_eventlog_filter->m_category_filter_commands->setChecked(!(GetRegStatusFlags() & RSF_EventLog_HideCommands));
+	m_eventlog_filter->m_category_filter_memory->setChecked(GetRegStatusFlags() & RSF_EventLog_ShowMemory);
+	m_eventlog_filter->m_category_filter_other->setChecked(!(GetRegStatusFlags() & RSF_EventLog_HideOther));
+
+	connect(m_eventlog_filter.get()->m_category_filter_commands, &QCheckBox::toggled, [eventlog_model_ptr](bool checkedState) { SetStatusFlag(RSF_EventLog_HideCommands, !checkedState); eventlog_model_ptr->refilter(); });
+	connect(m_eventlog_filter.get()->m_category_filter_memory, &QCheckBox::toggled, [eventlog_model_ptr](bool checkedState) { SetStatusFlag(RSF_EventLog_ShowMemory, checkedState); eventlog_model_ptr->refilter(); });
+	connect(m_eventlog_filter.get()->m_connection_filter, &QCheckBox::toggled, [eventlog_model_ptr](bool checkedState) { eventlog_model_ptr->refilter(); });
+	connect(m_eventlog_filter.get()->m_request_filter, &QCheckBox::toggled, [eventlog_model_ptr](bool checkedState) { eventlog_model_ptr->refilter(); });
+	connect(m_eventlog_filter.get()->m_category_filter_other, &QCheckBox::toggled, [eventlog_model_ptr](bool checkedState) { SetStatusFlag(RSF_EventLog_HideOther, !checkedState); eventlog_model_ptr->refilter(); });
 
 	m_eventlog_filter->m_clear_text_filter->setDisabled(true);
 	m_eventlog_filter->m_activate_text_filter->setDisabled(true);
@@ -439,6 +454,10 @@ DmsEventLog::DmsEventLog(QWidget* parent)
 	connect(m_eventlog_filter->m_activate_text_filter, &QPushButton::released, eventlog_model_ptr, &EventLogModel::refilterForTextFilter);
 	connect(m_eventlog_filter->m_text_filter, &QLineEdit::textChanged, this, &DmsEventLog::onTextChanged);
 	connect(m_eventlog_filter->m_clear_text_filter, &QPushButton::released, this, &DmsEventLog::clearTextFilter);
+
+	m_eventlog_filter->m_date_time->setChecked(dms_reg_status_flags & RSF_EventLog_ShowDateTime);
+	m_eventlog_filter->m_thread   ->setChecked(dms_reg_status_flags & RSF_EventLog_ShowThreadID);
+	m_eventlog_filter->m_category ->setChecked(dms_reg_status_flags & RSF_EventLog_ShowCategory);
 
 	connect(m_eventlog_filter->m_date_time, &QCheckBox::toggled, this, &DmsEventLog::invalidateOnVisualChange);
 	connect(m_eventlog_filter->m_thread   , &QCheckBox::toggled, this, &DmsEventLog::invalidateOnVisualChange);
@@ -599,11 +618,9 @@ void DmsEventLog::toggleFilter(bool toggled)
 
 void DmsEventLog::invalidateOnVisualChange()
 {
-	auto dms_reg_status_flags = GetRegStatusFlags();
-	setSF(m_eventlog_filter->m_date_time->isChecked(), dms_reg_status_flags, RSF_EventLog_ShowDateTime);
-	setSF(m_eventlog_filter->m_thread->isChecked(), dms_reg_status_flags, RSF_EventLog_ShowThreadID);
-	setSF(m_eventlog_filter->m_category->isChecked(), dms_reg_status_flags, RSF_EventLog_ShowCategory);
-	SetRegStatusFlags(dms_reg_status_flags);
+	SetStatusFlag(RSF_EventLog_ShowDateTime, m_eventlog_filter->m_date_time->isChecked());
+	SetStatusFlag(RSF_EventLog_ShowThreadID, m_eventlog_filter->m_thread   ->isChecked());
+	SetStatusFlag(RSF_EventLog_ShowCategory, m_eventlog_filter->m_category ->isChecked());
 
 	auto* eventlog_model = MainWindow::TheOne()->m_eventlog_model.get();
 	eventlog_model->cached_reg_flags = GetRegStatusFlags();

--- a/qtgui/exe/src/DmsOptions.cpp
+++ b/qtgui/exe/src/DmsOptions.cpp
@@ -233,13 +233,11 @@ void SetDrawingSizeTresholdValue(Float32 drawing_size)
 
 void DmsGuiOptionsWindow::apply()
 {
-    auto dms_reg_status_flags = GetRegStatusFlags();
-    setSF(m_follow_os_layout->isChecked(), dms_reg_status_flags, RSF_TreeView_FollowOSLayout);
-    setSF(m_show_hidden_items->isChecked(), dms_reg_status_flags, RSF_AdminMode);
-    setSF(m_show_thousand_separator->isChecked(), dms_reg_status_flags, RSF_ShowThousandSeparator);
-    setSF(m_toggle_debug_mode->isChecked(), dms_reg_status_flags, RSF_DebugMode);
-    setSF(m_show_state_colors_in_treeview->isChecked(), dms_reg_status_flags, RSF_ShowStateColors);
-    SetRegStatusFlags(dms_reg_status_flags);
+    SetStatusFlag(RSF_TreeView_FollowOSLayout, m_follow_os_layout             ->isChecked());
+    SetStatusFlag(RSF_AdminMode,               m_show_hidden_items            ->isChecked());
+    SetStatusFlag(RSF_ShowThousandSeparator,   m_show_thousand_separator      ->isChecked());
+    SetStatusFlag(RSF_DebugMode,               m_toggle_debug_mode            ->isChecked());
+    SetStatusFlag(RSF_ShowStateColors,         m_show_state_colors_in_treeview->isChecked());
 
     saveBackgroundColor(m_idle_color_ti_button, color_option::st_not_calculated);
     saveBackgroundColor(m_scheduled_color_ti_button, color_option::st_scheduled);
@@ -254,10 +252,10 @@ void DmsGuiOptionsWindow::apply()
     auto main_window = MainWindow::TheOne();
 
     // treeview follow os layout
-    main_window->m_treeview->setDmsStyleSheet(dms_reg_status_flags & RSF_TreeView_FollowOSLayout);
+    main_window->m_treeview->setDmsStyleSheet(GetRegStatusFlags() & RSF_TreeView_FollowOSLayout);
 
     // hidden items and state colors
-    main_window->m_eventlog_model->cached_reg_flags = dms_reg_status_flags;
+    main_window->m_eventlog_model->cached_reg_flags = GetRegStatusFlags();
     if (main_window->m_dms_model->updateChachedDisplayFlags())
         main_window->m_dms_model->reset();
 
@@ -487,13 +485,11 @@ void DmsLocalMachineOptionsWindow::apply()
     SetGeoDmsRegKeyString("SourceDataDir", m_sd_input->text().toStdString().c_str());
     SetGeoDmsRegKeyString("DmsEditor", (m_editor_input->text() + " " + m_editor_parameters_input->text()).toStdString().c_str());
 
-    auto dms_reg_status_flags = GetRegStatusFlags();
-    setSF(m_pp0->isChecked(), dms_reg_status_flags, RSF_SuspendForGUI);
-    setSF(m_pp1->isChecked(), dms_reg_status_flags, RSF_MultiThreading1);
-    setSF(m_pp2->isChecked(), dms_reg_status_flags, RSF_MultiThreading2);
-    setSF(m_pp3->isChecked(), dms_reg_status_flags, RSF_MultiThreading3);
-    setSF(m_tracelog->isChecked(), dms_reg_status_flags, RSF_TraceLogFile);
-    SetRegStatusFlags(dms_reg_status_flags);
+    SetStatusFlag(RSF_SuspendForGUI, m_pp0->isChecked());
+    SetStatusFlag(RSF_MultiThreading1, m_pp1->isChecked());
+    SetStatusFlag(RSF_MultiThreading2, m_pp2->isChecked());
+    SetStatusFlag(RSF_MultiThreading3, m_pp3->isChecked());
+    SetStatusFlag(RSF_TraceLogFile, m_tracelog->isChecked());
 
     MainWindow::TheOne()->updateTracelogHandle();
 
@@ -782,11 +778,5 @@ void DmsConfigOptionsWindow::cancel()
     done(QDialog::Rejected);
 }
 
-
-void SetRegStatusFlags(UInt32 newSF)
-{
-    SetGeoDmsRegKeyDWord("StatusFlags", newSF);
-    DMS_Appl_SetRegStatusFlags(newSF);
-}
 
 //======== END CONFIG OPTIONS WINDOW ========

--- a/qtgui/exe/src/DmsOptions.h
+++ b/qtgui/exe/src/DmsOptions.h
@@ -164,5 +164,3 @@ inline void setSF(bool value, UInt32& rsf, UInt32 flag)
         rsf &= ~flag;
 }
 
-void SetRegStatusFlags(UInt32 newSF);
-

--- a/rtc/dll/src/set/IndexedStrings.cpp
+++ b/rtc/dll/src/set/IndexedStrings.cpp
@@ -119,7 +119,7 @@ IndexedStrings<MustZeroTerminate, CharPtrRangeEqCmp, CharPtrRangeHasher>::GetOrC
 					{
 						auto warningStr = mgFormat2string("Depreciated mix-up of cases, tokenized '%s' as token %d and then seen '%s'", foundValue, foundIndex, keyValue);
 						PostMainThreadOper([warningStr] {
-							reportD(SeverityTypeID::ST_Warning, warningStr.c_str());
+							reportD(SeverityTypeID::ST_CaseMixup, warningStr.c_str());
 							}
 						);
 					}

--- a/rtc/dll/src/utl/Environment.cpp
+++ b/rtc/dll/src/utl/Environment.cpp
@@ -416,6 +416,34 @@ RTC_CALL void SetCachedStatusFlag(UInt32 newSF, bool newVal)
 		g_OvrStatusFlags |= newSF; // set
 	else
 		g_OvrStatusFlags &= ~newSF; // clear
+
+
+}
+
+RTC_CALL void SetRegStatusFlags(UInt32 newSF)
+{
+	SetGeoDmsRegKeyDWord("StatusFlags", newSF);
+	DMS_Appl_SetRegStatusFlags(newSF);
+}
+
+RTC_CALL void SetStatusFlag(UInt32 newSF, bool newVal)
+{
+	leveled_critical_section::scoped_lock lock(s_RegAccess);
+	g_OvrStatusMask |= newSF;
+	if (newVal)
+		g_OvrStatusFlags |= newSF; // set
+	else
+		g_OvrStatusFlags &= ~newSF; // clear
+
+	auto sf = ReadOnceRegisteredStatusFlags();
+	if (newVal)
+		sf |= newSF; // set
+	else
+		sf &= ~newSF; // clear
+
+	sf &= ~RSF_WasRead;
+	SetGeoDmsRegKeyDWord("StatusFlags", sf);
+	g_RegStatusFlags = (sf | RSF_WasRead);
 }
 
 RTC_CALL bool IsInDebugMode()

--- a/rtc/dll/src/utl/Environment.h
+++ b/rtc/dll/src/utl/Environment.h
@@ -100,8 +100,19 @@ enum RegStatusFlags
 	RSF_EventLog_ClearOnLoad = 0x40000,
 	RSF_EventLog_ClearOnReLoad = 0x80000,
 
-	RSF_TreeView_FollowOSLayout = 0x100000,
-	RSF_EventLog_HideDepreciated= 0x200000,
+	RSF_TreeView_FollowOSLayout  = 0x100000,
+	RSF_EventLog_ShowMinorTrace  = 0x200000,
+	RSF_EventLog_HideMajorTrace  = 0x400000,
+	RSF_EventLog_HideDepreciated = 0x800000,
+	RSF_EventLog_HideWarning     = 0x1000000,
+	RSF_EventLog_HideError       = 0x2000000,
+	RSF_EventLog_HideStorageRead = 0x4000000,
+	RSF_EventLog_HideStorageWrite= 0x8000000,
+//	RSF_EventLog_ShowConnection  = 0x10000000, out of bits, forget it
+//	RSF_EventLog_ShowRequest     = 0x20000000,out of bits, forget it
+	RSF_EventLog_HideCommands    = 0x10000000,
+	RSF_EventLog_ShowMemory      = 0x20000000,
+	RSF_EventLog_HideOther       = 0x40000000,
 
 	RSF_WasRead = 0x80000000,
 	RSF_Default = RSF_AdminMode | RSF_ShowStateColors | RSF_AllPanelsVisible | RSF_AllMultiThreading
@@ -110,6 +121,8 @@ enum RegStatusFlags
 
 RTC_CALL UInt32 GetRegStatusFlags();
 RTC_CALL void SetCachedStatusFlag(UInt32 newSF, bool newVal = true);
+RTC_CALL void SetRegStatusFlags(UInt32 newSF);
+RTC_CALL void SetStatusFlag(UInt32 newSF, bool newVal);
 RTC_CALL bool HasDynamicROI();
 RTC_CALL bool ShowThousandSeparator();
 RTC_CALL bool EventLog_HideDepreciatedCaseMixupWarnings();


### PR DESCRIPTION
#### PR Classification
Refactor and enhancement of event log filter persistence and UI consistency.

#### PR Summary
This PR refactors event log filter settings to use per-flag updates for immediate persistence and UI synchronization, introduces distinct handling for case mix-up warnings, and improves code clarity and safety.
- DmsEventLog.cpp: Replaces batch status flag updates with per-flag SetStatusFlag calls, updates filter checkbox initialization and connections, and distinguishes case mix-up warnings with a new color and severity type.
- Environment.cpp/h: Adds SetStatusFlag for atomic flag updates, moves SetRegStatusFlags, and extends RegStatusFlags with new filter-related flags.
- DmsOptions.cpp: Refactors options dialogs to use SetStatusFlag for individual settings.
- DmsEventLogSelection.ui: Adjusts checkbox widths and colors the "Case mix-up warnings" label for emphasis.
- IndexedStrings.cpp: Updates deprecated case mix-up warning reporting to use the new severity type.
